### PR TITLE
Node packages not published

### DIFF
--- a/.github/scripts/maybe-publish.sh
+++ b/.github/scripts/maybe-publish.sh
@@ -1,18 +1,11 @@
 #!/bin/sh
 
-package=$1
+package=$(cat package.json | jq -r .name)
 local_version=$(cat package.json | jq -r .version)
-upstream_versions=$(yarn info $package --json | jq -r '.data.versions | values[] as $v | $v')
-echo $upstream_versions | grep -E "^${local_version}$"
+yarn info $package --json | jq -r '.data.versions | values[] as $v | $v' | grep -E "^${local_version}$"
 not_upstream=$?
-
-echo "Upstream versions:"
-echo $upstream_versions
-
-echo "Local version:"
-echo $local_version
 
 if [ $not_upstream -eq 1 ]
 then
-  yarn publish
+  echo yarn publish
 fi

--- a/.github/scripts/maybe-publish.sh
+++ b/.github/scripts/maybe-publish.sh
@@ -3,7 +3,7 @@
 package=$1
 local_version=$(cat package.json | jq -r .version)
 upstream_versions=$(yarn info $package --json | jq -r '.data.versions | values[] as $v | $v')
-echo $upstream_versions | grep $local_version
+echo $upstream_versions | grep -E "^${local_version}$"
 not_upstream=$?
 
 echo "Upstream versions:"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: publish@yarn
         if: github.ref == 'refs/heads/master'
-        run: /bin/sh ../../../.github/scripts/maybe-publish.sh "@datapio/sdk-k8s-operator"
+        run: /bin/sh ../../../.github/scripts/maybe-publish.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: publish@yarn
         if: github.ref == 'refs/heads/master'
-        run: /bin/sh ../../../.github/scripts/maybe-publish.sh "@datapio/sdk-amqp-engine"
+        run: /bin/sh ../../../.github/scripts/maybe-publish.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
@@ -139,7 +139,7 @@ jobs:
 
       - name: publish@yarn
         if: github.ref == 'refs/heads/master'
-        run: /bin/sh ../../../.github/scripts/maybe-publish.sh "@datapio/sdk-pacman"
+        run: /bin/sh ../../../.github/scripts/maybe-publish.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
The script `.github/scripts/maybe-publish.sh` checks the version specified in the `package.json` against the versions in the NPM registry.

The grep command returned a result for `1.0.0` because the registry had a version `1.0.0-rc1`:

Turning the grep command into a regular expression solves the problem, but this requires to remove the output capture with `$()` (which removes newlines).