### PR TITLE
👕 disable max-class-per-file rule

### DIFF
--- a/sources/sdk/k8s-operator/.eslintrc
+++ b/sources/sdk/k8s-operator/.eslintrc
@@ -88,7 +88,7 @@
         "lines-around-comment": "error",
         "lines-around-directive": "error",
         "lines-between-class-members": "error",
-        "max-classes-per-file": "error",
+        "max-classes-per-file": "off",
         "max-depth": "error",
         "max-len": "warn",
         "max-lines": "error",


### PR DESCRIPTION
It isn't incorrect to have your exceptions alongside the module that use them.