### PR TITLE
Add AnnotationField in sdk-k8s-operator GraphQL utilities.

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/graphql/type-defs/annotation.graphql
+++ b/sources/sdk/k8s-operator/src/graphql/type-defs/annotation.graphql
@@ -2,3 +2,8 @@ type Annotation {
   name: String!
   value: String!
 }
+
+input AnnotationField {
+  name: String!
+  value: String!
+}


### PR DESCRIPTION
The provided `Annotation` type in the GraphQL type definitions of the SDK was the only one without a corresponding input.

**NB:** in a later versions, validators for labels and annotations will be provided. They have the same structure but not the same syntax. The validators will be added as a GraphQL directive.