### PR TITLE
🐛 Wrong type in SDK Kubernetes Operator

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/web-service.js
+++ b/sources/sdk/k8s-operator/src/web-service.js
@@ -6,7 +6,7 @@ class WebService {
     this.servers = serverFactory.make(this.operator.webapp)
     this.cancelScopes = []
 
-    this.servers.map(server => createTerminus(server, {
+    this.servers.map(({ server }) => createTerminus(server, {
       healthChecks: {
         '/health': this.operator.healthCheck.bind(this.operator),
         '/metrics': this.operator.metrics.bind(this.operator),


### PR DESCRIPTION
Since the `createTerminus` method has been mocked, it failed the unit tests.

**NB:** E2E (End-To-End) tests are not yet automated.