### PR TITLE
🐛 Fix KubeConfig creation and CRD double-creation

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -64,6 +64,18 @@ class Operator {
       const ctx = await userContext({ req, ...args })
 
       const kubeConfig = new kubernetes.KubeConfig()
+
+      kubeConfig.loadFromString(
+        JSON.stringify({
+          apiVersion: 'v1',
+          kind: 'Config',
+          clusters: [],
+          users: [],
+          contexts: [],
+          'current-context': '',
+        })
+      )
+
       kubeConfig.addCluster(this.kubectl.config.getCurrentCluster())
       kubeConfig.addUser({
         name: 'graphql-client',

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -91,6 +91,7 @@ class Operator {
 
       const kubectl = new KubeInterface({
         crds: this.kubectl.crds,
+        createCRDs: false,
         config: kubeConfig
       })
       await kubectl.load()


### PR DESCRIPTION
The `kubernetes-client` dependency (the high level API) relies on the last LTS of `@kubernetes/client-node` (the low level API).

This version requires the `KubeConfig` class to be initialized at least with an empty configuration.

On a second note, the service account tied to the token used for authentication in the `ApolloServer` is unlikely to have the access permissions to CRDs API endpoints. It is also redundant to try to create the CRDs on each requests AND at startup.