### PR TITLE
🐛 Fix Kubernetes interface

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -225,7 +225,7 @@ class KubeInterface {
     return response.unwrap(await endpoint.patch({
       body: patch,
       headers: {
-        content_type: 'application/merge-patch+json'
+        'content-type': 'application/merge-patch+json'
       }
     }))
   }

--- a/sources/sdk/k8s-operator/src/resource-watcher.js
+++ b/sources/sdk/k8s-operator/src/resource-watcher.js
@@ -19,7 +19,7 @@ class ResourceWatcher {
     }
 
     stream.on('data', async ({ type, object }) => {
-      const handler = handlers[type]
+      const handler = handlers[type.toLowerCase()]
       await handler(operator, object)
     })
 


### PR DESCRIPTION
When the operator starts, it receives the complete history of the watched resources.

The events are `ADDED`, `MODIFIED` and `DELETED`. **They are not lowercase.**

Finally, the Kubernetes client backend expect lowercase HTTP headers, but the `-` is not replaced/transformed.

Silly mistakes, but we're getting closer to a stable release.