### PR TITLE
WIP: ✨ Add support for authentication via HTTP Only cookie

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -35,6 +35,7 @@
     "@godaddy/terminus": "^4.4.1",
     "@kubernetes/client-node": "^0.12.2",
     "apollo-server-express": "^2.18.2",
+    "cookie-parser": "^1.4.5",
     "kubernetes-client": "^9.0.0",
     "merge-options": "^3.0.3"
   }

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -24,17 +24,19 @@ const defaultHttpApiFactory = () =>
     response.end('default backend')
   }
 
+const getCookieToken = req => req.signedCookies[AUTH_COOKIE_NAME] ||
+req.cookies[AUTH_COOKIE_NAME]
+
+const getAuthorizationToken = req => {
+  const authorization = req.get('authorization')
+  return authorization.startsWith('Bearer ') && authorization.substring(7)
+}
 
 const getAuthToken = req => {
-  let result = req.signedCookies[AUTH_COOKIE_NAME] ||
-    req.cookies[AUTH_COOKIE_NAME]
+  const result = getCookieToken(req) || getAuthorizationToken(req)
 
   if (!result) {
-    const authorization = req.get('authorization')
-    if (!(authorization && authorization.startsWith('Bearer '))) {
-      throw new OperatorError('Invalid token')
-    }
-    result = authorization.substring(7, authorization.length)
+    throw new OperatorError('Invalid token')
   }
 
   return result

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -26,17 +26,15 @@ const defaultHttpApiFactory = () =>
 
 
 const getAuthToken = req => {
-  let result
-  if (AUTH_COOKIE_NAME in req.cookies) {
-    result = req.cookies[AUTH_COOKIE_NAME]
-  } else if (AUTH_COOKIE_NAME in req.signedCookies) {
-    result = req.signedCookies[AUTH_COOKIE_NAME]
-  } else {
+  let result = req.signedCookies[AUTH_COOKIE_NAME] ||
+    req.cookies[AUTH_COOKIE_NAME]
+
+  if (!result) {
     const authorization = req.get('authorization')
     if (!(authorization && authorization.startsWith('Bearer '))) {
       throw new OperatorError('Invalid token')
     }
-    result = authorization.substring(7, header.length)
+    result = authorization.substring(7, authorization.length)
   }
 
   return result
@@ -96,9 +94,9 @@ class Operator {
       )
 
       kubeConfig.addCluster(this.kubectl.config.getCurrentCluster())
-      
+
       const token = getAuthToken(req)
-            
+
       kubeConfig.addUser({
         name: 'graphql-client',
         token

--- a/sources/sdk/k8s-operator/yarn.lock
+++ b/sources/sdk/k8s-operator/yarn.lock
@@ -1373,6 +1373,14 @@ convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
+  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
When a token is sent via the `Authorization` HTTP header to the Apollo Server, it is used to authenticate the requests made to the Kubernetes API Server.

In order to avoid needlessly sending the token on each request, an HTTP-Only cookie should be sent back in the response whenever a token is received in the `Authorization` header.

When no token is found in the `Authorization` header, the Apollo Server should check for the cookie's presence.