### PR TITLE
✨ Add support for authentication via HTTP Only cookie

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "lint": "eslint src/",
-    "test": "c8 -n src/ -a -r html -r text mocha -r tests/mocks/index.js tests/**/*.spec.js"
+    "test": "c8 -n src/ -a -r html -r text mocha -r tests/mocks/index.js tests/**/*.spec.js tests/*.spec.js"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -36,6 +36,7 @@
     "@godaddy/terminus": "^4.4.1",
     "@kubernetes/client-node": "^0.13.0",
     "apollo-server-express": "^2.19.0",
+    "cookie-parser": "^1.4.5",
     "kubernetes-client": "^9.0.0",
     "merge-options": "^3.0.3"
   }

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -28,7 +28,9 @@ const authTokenProcessorFactory = name => (req, res) => {
   const authHeader = () => {
     const authorization = req.get('authorization')
     if (authorization && !authorization.startsWith('Bearer ')) {
-      throw new OperatorError('Invalid Authorization header. \'Bearer\' expected')
+      throw new OperatorError(
+        'Invalid Authorization header. \'Bearer\' expected'
+      )
     }
     return authorization?.substring(7)
   }

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -27,9 +27,10 @@ const authTokenProcessorFactory = name => (req, res) => {
   const signedCookie = () => req.signedCookies[name]
   const authHeader = () => {
     const authorization = req.get('authorization')
-    return authorization &&
-      authorization.startsWith('Bearer ') &&
-      authorization.substring(7)
+    if (authorization && !authorization.startsWith('Bearer ')) {
+      throw new OperatorError('Invalid Authorization header. \'Bearer\' expected')
+    }
+    return authorization?.substring(7)
   }
   const getToken = () => authHeader() || signedCookie() || null
   const setToken = token => res.setHeader(

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -24,17 +24,19 @@ const defaultHttpApiFactory = () =>
     response.end('default backend')
   }
 
+const getCookieToken = req => req.signedCookies[AUTH_COOKIE_NAME] ||
+req.cookies[AUTH_COOKIE_NAME]
+
+const getAuthorizationToken = req => {
+  const authorization = req.get('authorization')
+  return authorization.startsWith('Bearer ') && authorization.substring(7)
+}
 
 const getAuthToken = req => {
-  let result = req.signedCookies[AUTH_COOKIE_NAME] ||
-    req.cookies[AUTH_COOKIE_NAME]
+  const result = getCookieToken(req) || getAuthorizationToken(req)
 
   if (!result) {
-    const authorization = req.get('authorization')
-    if (!(authorization && authorization.startsWith('Bearer '))) {
-      throw new OperatorError('Invalid token')
-    }
-    result = authorization.substring(7, authorization.length)
+    throw new OperatorError('Invalid token')
   }
 
   return result

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -26,17 +26,15 @@ const defaultHttpApiFactory = () =>
 
 
 const getAuthToken = req => {
-  let result
-  if (AUTH_COOKIE_NAME in req.cookies) {
-    result = req.cookies[AUTH_COOKIE_NAME]
-  } else if (AUTH_COOKIE_NAME in req.signedCookies) {
-    result = req.signedCookies[AUTH_COOKIE_NAME]
-  } else {
+  let result = req.signedCookies[AUTH_COOKIE_NAME] ||
+    req.cookies[AUTH_COOKIE_NAME]
+
+  if (!result) {
     const authorization = req.get('authorization')
     if (!(authorization && authorization.startsWith('Bearer '))) {
       throw new OperatorError('Invalid token')
     }
-    result = authorization.substring(7, header.length)
+    result = authorization.substring(7, authorization.length)
   }
 
   return result
@@ -96,9 +94,9 @@ class Operator {
       )
 
       kubeConfig.addCluster(this.kubectl.config.getCurrentCluster())
-      
+
       const token = getAuthToken(req)
-            
+
       kubeConfig.addUser({
         name: 'graphql-client',
         token

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -29,7 +29,7 @@ const makeAuthToken = name => ({
   },
   authHeader(req) {
     const authorization = req.get('authorization')
-    return authorization.substring(7, authorization.length)
+    return authorization && res.startsWith('Bearer ') && authorization.substring(7)
   },
   get(req) {
     return this.authHeader(req) ||

--- a/sources/sdk/k8s-operator/tests/operator.spec.js
+++ b/sources/sdk/k8s-operator/tests/operator.spec.js
@@ -52,7 +52,7 @@ describe('Operator', () => {
   })
 
   describe('ApolloServer', () => {
-    it('should have a new KubeInterface per authenticated request', async () => {
+    it('should have a new KubeInterface per authenticated request with auth header', async () => {
       const expectedFoo = casual.word
       const context = sinon.stub().resolves({foo: expectedFoo})
       const operator = new Operator({
@@ -66,28 +66,65 @@ describe('Operator', () => {
       const req = {
         get: sinon.stub().returns(`Bearer ${expectedToken}`)
       }
+      const res = {
+        setHeader: sinon.stub()
+      }
 
-      const result = await operator.apollo.options.context({ req })
+      const result = await operator.apollo.options.context({ req, res })
       sinon.assert.calledOnce(context)
       sinon.assert.calledWith(req.get, 'authorization')
+      sinon.assert.calledWith(res.setHeader, 'Set-Cookie')
 
       expect(result.foo).to.equal(expectedFoo)
       const { token } = result.kubectl.config.getCurrentUser()
       expect(token).to.equal(expectedToken)
     })
 
-    it('should fail if no Bearer token is provided', async () => {
+    it('should have a new KubeInterface per authenticated request with auth cookie', async () => {
+      const expectedFoo = casual.word
+      const context = sinon.stub().resolves({foo: expectedFoo})
+      const operator = new Operator({
+        apolloOptions: { context },
+        kubeOptions: {
+          config: kubeFixture.config
+        }
+      })
+
+      const expectedToken = casual.word
+      const req = {
+        get: sinon.stub().returnsArg(0),
+        signedCookies: {
+          'X-Datapio-Auth-Token': expectedToken
+        }
+      }
+      const res = {
+        setHeader: sinon.stub()
+      }
+
+      const result = await operator.apollo.options.context({ req, res })
+      sinon.assert.calledOnce(context)
+      sinon.assert.calledWith(req.get, 'authorization')
+      sinon.assert.calledWith(res.setHeader, 'Set-Cookie')
+
+      expect(result.foo).to.equal(expectedFoo)
+      const { token } = result.kubectl.config.getCurrentUser()
+      expect(token).to.equal(expectedToken)
+    })
+
+    it('should fail if no Bearer token nor auth cookie is provided', () => {
       const operator = new Operator({
         kubeOptions: {
           config: kubeFixture.config
         }
       })
       const req = {
-        get: sinon.stub()
+        get: sinon.stub().returnsArg(0),
+        signedCookies: {}
       }
 
-      const promise = operator.apollo.options.context({ req })
-      expect(promise).to.be.rejectedWith(Operator.Error)
+      const context = operator.apollo.options.context({ req })
+
+      expect(context).to.be.rejectedWith(Operator.OperatorError)
     })
   })
 })

--- a/sources/sdk/k8s-operator/tests/operator.spec.js
+++ b/sources/sdk/k8s-operator/tests/operator.spec.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 const casual = require('casual')
 
 const { Operator } = require('../src/index')
-const kubeFixture =require('./fixtures/kubectl')
+const kubeFixture = require('./fixtures/kubectl')
 
 describe('Operator', () => {
   beforeEach(setUp)

--- a/sources/sdk/k8s-operator/yarn.lock
+++ b/sources/sdk/k8s-operator/yarn.lock
@@ -1356,6 +1356,14 @@ convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
+  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
When a token is sent via the `Authorization` HTTP header to the Apollo Server, it is used to authenticate the requests made to the Kubernetes API Server.

In order to avoid needlessly sending the token on each request, an HTTP-Only cookie should be sent back in the response whenever a token is received in the `Authorization` header.

When no token is found in the `Authorization` header, the Apollo Server should check for the cookie's presence.