### PR TITLE
🔨 Load all CRDs present in Kubernetes cluster

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -102,7 +102,7 @@ class KubeInterface {
     const extension = this.client.apis['apiextensions.k8s.io'].v1beta1
     const api = extension.customresourcedefinitions
 
-    const remoteCRDs = await api.get()
+    const remoteCRDs = response.unwrap(await api.get(), true)
     const missingCRDs = this.crds.filter(
       crd => remoteCRDs.filter(
         remoteCRD => crd.metadata.name === remoteCRD.metadata.name

--- a/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
+++ b/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
@@ -8,10 +8,29 @@ describe('KubeInterface', () => {
   beforeEach(setUp)
 
   it('should create a client a load the server API specification', async () => {
-    const kubectl = new KubeInterface({})
+    const kubectl = new KubeInterface({ crds: [
+      {
+        metadata: {
+          name: 'crd-foo'
+        }
+      }
+    ]})
     await kubectl.load()
 
     sinon.assert.calledOnce(kubectl.client.loadSpec)
+
+    sinon.assert.calledWith(
+      kubectl.client.addCustomResourceDefinition,
+      { metadata: { name: 'crd1' }}
+    )
+    sinon.assert.calledWith(
+      kubectl.client.addCustomResourceDefinition,
+      { metadata: { name: 'crd2' }}
+    )
+    sinon.assert.calledWith(
+      kubectl.client.addCustomResourceDefinition,
+      { metadata: { name: 'crd-foo' }}
+    )
   })
 
   require('./create')()

--- a/sources/sdk/k8s-operator/tests/mocks/kubernetes-client.js
+++ b/sources/sdk/k8s-operator/tests/mocks/kubernetes-client.js
@@ -42,7 +42,31 @@ const failure = makeNamed(
   }
 )
 
+const customresourcedefinitions = makeNamed(
+  {
+    get: sinon.stub().resolves({ statusCode: 200, body: { items: [
+      {
+        metadata: {
+          name: 'crd1'
+        }
+      },
+      {
+        metadata: {
+          name: 'crd2'
+        }
+      }
+    ] }}),
+    post: sinon.stub().resolves({ statusCode: 200, body: 'DATA' })
+  },
+  {}
+)
+
 const apis = {
+  'apiextensions.k8s.io': {
+    'v1beta1': {
+      customresourcedefinitions
+    }
+  },
   'example.com': {
     'v1': {
       watch: {
@@ -66,6 +90,7 @@ class Client {
     this.loadSpec = sinon.stub().resolves()
     this.apis = apis
     this.api = apis['example.com']
+    this.addCustomResourceDefinition = sinon.stub()
   }
 }
 


### PR DESCRIPTION
In the Kubernetes client, the `watch` endpoint for Custom Resources exists only if the client method `addCustomResourceDefinition()` has been called.

Therefore, the `KubeInterface` should request all the CRDs known by the Kubernetes API Server to initialize the client correctly.

**When will this PR be ready?**

 - [x] 🔨  `KubeInterface` class loads the CRDs
 - [x] 🚨 Test coverage
 - [x] 🔖 Version bump