### PR TITLE
👷‍♀️ add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/sources/sdk/k8s-operator"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/sources/sdk/amqp-engine"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/sources/sdk/pacman"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will enable the Dependabot dependency graph in the Insight tab.