### PR TITLE
✅ Add missing mock dependency

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -29,7 +29,8 @@
     "eslint": "^7.13.0",
     "mocha": "^8.2.1",
     "mock-require": "^3.0.3",
-    "sinon": "^9.2.1"
+    "sinon": "^9.2.1",
+    "through": "^2.3.8"
   },
   "dependencies": {
     "@godaddy/terminus": "^4.4.1",

--- a/sources/sdk/k8s-operator/yarn.lock
+++ b/sources/sdk/k8s-operator/yarn.lock
@@ -3692,6 +3692,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+through@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 tmp-promise@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"


### PR DESCRIPTION
The previous version of `kubernetes/client-node` used `through` as dependency to create the stream objects for the `watch` endpoint.

We used this dependency as well in our mocks to emulate the Kubernetes client.

This PR reintroduces the dependency in `devDependencies` to fix the test suite.