### PR TITLE
👷‍♂️ ⬆ Upgrade NodeJS

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -20,7 +20,7 @@ jobs:
       - name: setup@node
         uses: actions/setup-node@master
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           always-auth: true
           registry-url: https://npm.pkg.github.com
           scope: '@datapio'
@@ -69,7 +69,7 @@ jobs:
       - name: setup@node
         uses: actions/setup-node@master
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           always-auth: true
           registry-url: https://npm.pkg.github.com
           scope: '@datapio'
@@ -118,7 +118,7 @@ jobs:
       - name: setup@node
         uses: actions/setup-node@master
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           always-auth: true
           registry-url: https://npm.pkg.github.com
           scope: '@datapio'
@@ -167,7 +167,7 @@ jobs:
       - name: setup@node
         uses: actions/setup-node@master
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           always-auth: true
           registry-url: https://npm.pkg.github.com
           scope: '@datapio'
@@ -204,7 +204,7 @@ jobs:
       - name: setup@node
         uses: actions/setup-node@master
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           always-auth: true
           registry-url: https://npm.pkg.github.com
           scope: '@datapio'


### PR DESCRIPTION
We are using NodeJS 14.X (LTS).

The CI pipeline was still using the old 12.X version branch.