### PR TITLE
🐛 KubeInterface client's method not binded

### DIFF
--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -120,7 +120,7 @@ class KubeInterface {
       ...missingCRDs
     ]
 
-    this.crds.map(this.client.addCustomResourceDefinition)
+    this.crds.map(this.client.addCustomResourceDefinition.bind(this.client))
   }
 
   async create(...resources) {


### PR DESCRIPTION
The methd `client.addCustomResourceDefinion` is used in a map, but its `this` argument was undefined.