### PR TITLE
✨ KubeInterface access review

### DIFF
--- a/sources/sdk/k8s-operator/src/kube-interface-utils.js
+++ b/sources/sdk/k8s-operator/src/kube-interface-utils.js
@@ -1,0 +1,106 @@
+class KubeError extends Error {
+  constructor(msg, details = null) {
+    super(msg)
+    this.name = this.constructor.name
+    this.details = details
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+const defaultCallback = async () => ({ condition: true, res: null })
+
+const parseApiVersion = apiVersion =>
+  // eslint-disable-next-line max-len
+  (/^(?:(?<apiGroup>[a-zA-Z][a-zA-Z0-9\-_.]*)\/)?(?<resourceVersion>.*)$/u).exec(apiVersion).groups
+
+const getEndpoint = (client, meta, watch = false) => {
+  const {
+    apiGroup,
+    resourceVersion,
+    kind,
+    namespace,
+    name
+  } = meta
+
+  const fns = [
+    () => {
+      return apiGroup
+        ? client.apis[apiGroup][resourceVersion]
+        : client.api[resourceVersion]
+    },
+    ep => {
+      return watch ? ep.watch : ep
+    },
+    ep => {
+      return namespace ? ep.namespaces(namespace) : ep
+    },
+    ep => {
+      return ep[kind.toLowerCase()]
+    },
+    ep => {
+      return name ? ep(name) : ep
+    }
+  ]
+
+  try {
+    return fns.reduce(
+      (ep, fn) => fn(ep),
+      null
+    )
+  }
+  catch (err) {
+    throw new KubeError(
+      'Unknown API',
+      {
+        meta,
+        err
+      }
+    )
+  }
+}
+
+const response = {
+  assertStatusCode: resp => {
+    if (resp.statusCode < 200 || resp.statusCode >= 300) {
+      throw new KubeError(
+        'Unexpected response from Kubernetes API Server',
+        {
+          resp
+        }
+      )
+    }
+  },
+  unwrap: (resp, many = false) => {
+    response.assertStatusCode(resp)
+    return many ? resp.body.items : resp.body
+  }
+}
+
+
+const makeReviewer = (kubectl, reviewKind) =>
+  async ({ apiVersion, kind, namespace, verb }) => {
+    const { apiGroup } = parseApiVersion(apiVersion)
+    const resp = await kubectl.create({
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: reviewKind,
+      spec: {
+        resourceAttributes: {
+          group: apiGroup,
+          resource: kind.toLowerCase(),
+          verb,
+          namespace
+        }
+      }
+    })
+
+    return resp.status
+  }
+
+module.exports = {
+  KubeError,
+  defaultCallback,
+  parseApiVersion,
+  getEndpoint,
+  response,
+  makeReviewer
+}

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -226,7 +226,7 @@ class KubeInterface {
     const reviewKind = meta.namespace ? 'LocalSubjectAccessReview' : 'SubjectAccessReview'
     const reviewer = makeReviewer(this, reviewKind)
     const review = await reviewer(meta)
-    return review.allowed.allowed
+    return review.allowed
   }
 
   async myAccessRules({ scopes = [] }) {

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -127,7 +127,7 @@ class KubeInterface {
     return await Promise.all(resources
       .map(resource => ({
         kind: resource.kind,
-        namespace: resource.metadata.namespace,
+        namespace: resource.metadata?.namespace,
         body: resource,
         ...parseApiVersion(resource.apiVersion)
       }))
@@ -284,6 +284,24 @@ class KubeInterface {
         container
       }
     }))
+  }
+
+  async canI({ apiVersion, kind, namespace, verb }) {
+    const { apiGroup } = parseApiVersion(apiVersion)
+    const resp = await this.create({
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'SelfSubjectAccessReview',
+      spec: {
+        resourceAttributes: {
+          group: apiGroup,
+          resource: kind.toLowerCase(),
+          verb,
+          namespace
+        }
+      }
+    })
+
+    return resp.status.allowed
   }
 }
 

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -303,6 +303,42 @@ class KubeInterface {
 
     return resp.status.allowed
   }
+
+  async canThey({ apiVersion, kind, namespace, verb }) {
+    const { apiGroup } = parseApiVersion(apiVersion)
+    const resp = await this.create({
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: namespace ? 'LocalSubjectAccessReview' : 'SubjectAccessReview',
+      spec: {
+        resourceAttributes: {
+          group: apiGroup,
+          resource: kind.toLowerCase(),
+          verb,
+          namespace
+        }
+      }
+    })
+
+    return resp.status.allowed
+  }
+
+  async myAccessRules({ apiVersion, kind, namespace, verb }) {
+    const { apiGroup } = parseApiVersion(apiVersion)
+    const resp = await this.create({
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'SelfSubjectRulesReview',
+      spec: {
+        resourceAttributes: {
+          group: apiGroup,
+          resource: kind.toLowerCase(),
+          verb,
+          namespace
+        }
+      }
+    })
+
+    return resp.status.allowed
+  }
 }
 
 KubeInterface.Error = KubeError

--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -1,105 +1,14 @@
 const Request = require('kubernetes-client/backends/request')
 const kubernetes = require('kubernetes-client')
 
-
-class KubeError extends Error {
-  constructor(msg, details = null) {
-    super(msg)
-    this.name = this.constructor.name
-    this.details = details
-    Error.captureStackTrace(this, this.constructor)
-  }
-}
-
-const defaultCallback = async () => ({ condition: true, res: null })
-
-const parseApiVersion = apiVersion =>
-  // eslint-disable-next-line max-len
-  (/^(?:(?<apiGroup>[a-zA-Z][a-zA-Z0-9\-_.]*)\/)?(?<resourceVersion>.*)$/u).exec(apiVersion).groups
-
-const getEndpoint = (client, meta, watch = false) => {
-  const {
-    apiGroup,
-    resourceVersion,
-    kind,
-    namespace,
-    name
-  } = meta
-
-  const fns = [
-    () => {
-      return apiGroup
-        ? client.apis[apiGroup][resourceVersion]
-        : client.api[resourceVersion]
-    },
-    ep => {
-      return watch ? ep.watch : ep
-    },
-    ep => {
-      return namespace ? ep.namespaces(namespace) : ep
-    },
-    ep => {
-      return ep[kind.toLowerCase()]
-    },
-    ep => {
-      return name ? ep(name) : ep
-    }
-  ]
-
-  try {
-    return fns.reduce(
-      (ep, fn) => fn(ep),
-      null
-    )
-  }
-  catch (err) {
-    throw new KubeError(
-      'Unknown API',
-      {
-        meta,
-        err
-      }
-    )
-  }
-}
-
-const response = {
-  assertStatusCode: resp => {
-    if (resp.statusCode < 200 || resp.statusCode >= 300) {
-      throw new KubeError(
-        'Unexpected response from Kubernetes API Server',
-        {
-          resp
-        }
-      )
-    }
-  },
-  unwrap: (resp, many = false) => {
-    response.assertStatusCode(resp)
-    return many ? resp.body.items : resp.body
-  }
-}
-
-
-const makeReviewer = (kubectl, reviewKind) =>
-  async ({ apiVersion, kind, namespace, verb }) => {
-    const { apiGroup } = parseApiVersion(apiVersion)
-    const resp = await kubectl.create({
-      apiVersion: 'authorization.k8s.io/v1',
-      kind: reviewKind,
-      spec: {
-        resourceAttributes: {
-          group: apiGroup,
-          resource: kind.toLowerCase(),
-          verb,
-          namespace
-        }
-      }
-    })
-
-    return resp.status
-  }
-
+const {
+  KubeError,
+  defaultCallback,
+  parseApiVersion,
+  getEndpoint,
+  response,
+  makeReviewer
+} = require('./kube-interface-utils')
 
 class KubeInterface {
   constructor({ crds = [], createCRDs = true, config = null }) {
@@ -321,13 +230,10 @@ class KubeInterface {
   }
 
   async myAccessRules({ scopes = [] }) {
-    const { apiGroup } = parseApiVersion(apiVersion)
     const resp = await this.create({
       apiVersion: 'authorization.k8s.io/v1',
       kind: 'SelfSubjectRulesReview',
-      spec: {
-        scopes
-      }
+      spec: { scopes }
     })
 
     return resp.status


### PR DESCRIPTION
See [Kubernetes Authorization Overview](https://kubernetes.io/docs/reference/access-authn-authz/authorization/) for more informations.

This PR adds methods to the `KubeInterface` class, allowing the user to query the Kubernetes API Server for its authorizations.

**When will this PR be ready?**

 - [x] :sparkles: `canI` method for a `SelfSubjectAccessReview`
 - [x] :sparkles: `canThey` method for a `SubjectAccessReview` or a `LocalSubjectAccessReview`
 - [x] :sparkles: `myAccessRules` method for a `SelfSubjectRulesReview`
 - [ ] :rotating_light: Test coverage