### PR TITLE
🔖🐛 Fix route /graphql/logout and upgrade to 1.4.1

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -78,6 +78,7 @@ class Operator {
     this.webapp.use('/api', this.api)
     this.webapp.get('/graphql/logout', (req, res) => {
       res.cookie(authCookieName, { expires: Date.now() })
+      res.end('')
     })
 
     const apolloRealOptions = mergeOptions(


### PR DESCRIPTION
This PR aims to fix any requests to /graphql/logout (delete authentication httpOnly cookies) and add minor version