### PR TITLE
🔖🐛 Fix GraphQL collection helper (v1.5.1)

### DIFF
--- a/sources/sdk/k8s-operator/package.json
+++ b/sources/sdk/k8s-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datapio/sdk-k8s-operator",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Kubernetes Operator factory",
   "main": "src/index.js",
   "repository": {

--- a/sources/sdk/k8s-operator/src/graphql/utils/collection.js
+++ b/sources/sdk/k8s-operator/src/graphql/utils/collection.js
@@ -19,7 +19,7 @@ const sort = (items, { key, reversed = false }) => {
 const pagination = (items, { offset = 0, limit = Number.MAX_SAFE_INTEGER }) =>
   items.slice(offset).slice(0, limit)
 
-const collection = (parent, { paging, sorting }) =>
+const collection = (parent, { paging = {}, sorting = {} }) =>
   pagination(
     sorting ? sort(parent.items, sorting) : parent.items,
     paging


### PR DESCRIPTION
This PR provides sane defaults for `paging` and `sorting` within the `collection` helper, preventing an error when they are not supplied.