### PR TITLE
✨ Make HTTP server optional

### DIFF
--- a/sources/sdk/k8s-operator/src/errors.js
+++ b/sources/sdk/k8s-operator/src/errors.js
@@ -1,0 +1,11 @@
+class OperatorError extends Error {
+  constructor(msg) {
+    super(msg)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+module.exports = {
+  OperatorError
+}

--- a/sources/sdk/k8s-operator/src/operator.js
+++ b/sources/sdk/k8s-operator/src/operator.js
@@ -9,14 +9,7 @@ const crypto = require('crypto')
 const ServerFactory = require('./server-factory')
 const WebService = require('./web-service')
 const KubeInterface = require('./kube-interface')
-
-class OperatorError extends Error {
-  constructor(msg) {
-    super(msg)
-    this.name = this.constructor.name
-    Error.captureStackTrace(this, this.constructor)
-  }
-}
+const { OperatorError } = require('./errors')
 
 const defaultHttpApiFactory = () =>
   (request, response) => {

--- a/sources/sdk/k8s-operator/src/server-factory.js
+++ b/sources/sdk/k8s-operator/src/server-factory.js
@@ -3,6 +3,8 @@ const https = require('https')
 const http = require('http')
 const fs = require('fs')
 
+const { OperatorError } = require('./errors')
+
 class ServerFactory {
   defaultOptions = {
     https: {
@@ -13,6 +15,7 @@ class ServerFactory {
       ca: '/path/to/ca.pem'
     },
     http: {
+      enabled: true,
       port: 8000
     }
   }
@@ -22,12 +25,14 @@ class ServerFactory {
   }
 
   make(api) {
-    const servers = [
-      {
+    const servers = []
+
+    if (this.options.http.enabled) {
+      servers.push({
         server: http.createServer(api),
         port: this.options.http.port
-      }
-    ]
+      })
+    }
 
     if (this.options.https.enabled) {
       servers.push({
@@ -41,6 +46,10 @@ class ServerFactory {
         ),
         port: this.options.https.port
       })
+    }
+
+    if (servers.length === 0) {
+      throw new OperatorError('No server configured')
     }
 
     return servers


### PR DESCRIPTION
This PR introduce the following changes:

 - [x] :sparkles: new `serverOptions.http.enabled` flag set to `true` by default
 - [x] :hammer: assert there is at least one server enabled 
 - [x] :white_check_mark: Test Coverage