### PR TITLE
✨ Add possibility to override patch type

### DIFF
--- a/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
+++ b/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
@@ -40,5 +40,5 @@ describe('KubeInterface', () => {
   describe('patch', require('./patch'))
   describe('delete', require('./delete'))
   describe('logs', require('./logs'))
-  describe.skip('exec', require('./exec'))
+  describe('exec', require('./exec'))
 })

--- a/sources/sdk/k8s-operator/tests/kube-interface/patch.js
+++ b/sources/sdk/k8s-operator/tests/kube-interface/patch.js
@@ -40,8 +40,32 @@ module.exports = () => {
     }
     catch (err) {
       expect(err.name).to.equal('KubeError')
-      expect(err.details.resp.statusCode).to.equal(404)
-      expect(err.details.resp.body).to.equal('ERROR')
+      expect(err.details?.resp?.statusCode).to.equal(404)
+      expect(err.details?.resp?.body).to.equal('ERROR')
+    }
+  })
+
+  it('should throw an error if the patchType is invalid', async () => {
+    const kubectl = new KubeInterface({})
+    await kubectl.load()
+
+    try {
+      await kubectl.patch({
+        apiVersion: 'example.com/v1',
+        kind: 'Failure',
+        namespace: 'default',
+        name: 'example',
+        patch: {
+          spec: { foo: 'bar' }
+        },
+        patchType: 'invalid'
+      })
+
+      throw new Error('no error has been thrown')
+    }
+    catch (err) {
+      expect(err.name).to.equal('KubeError')
+      expect(err.details?.patchType).to.equal('invalid')
     }
   })
 }


### PR DESCRIPTION
This PR introduces the following changes:

 - [x] :sparkles: Add `patchType` parameter to `KubeInterface.patch()` method
 - [x] :wrench: Set `patchType` to `'merge'` by default (backward compatiblity)
 - [x] :white_check_mark: Test Coverage 