### PR TITLE
✨ Add replace method to KubeInterface

### DIFF
--- a/sources/sdk/k8s-operator/src/kube-interface.js
+++ b/sources/sdk/k8s-operator/src/kube-interface.js
@@ -178,6 +178,19 @@ class KubeInterface {
     }))
   }
 
+  async replace(resource) {
+    const { apiGroup, resourceVersion } = parseApiVersion(resource.apiVersion)
+    const endpoint = getEndpoint(this.client, {
+      apiGroup,
+      resourceVersion,
+      kind: resource.kind,
+      namespace: resource.metadata.namespace,
+      name: resource.metadata.name
+    })
+
+    return response.unwrap(await endpoint.put({ body: resource }))
+  }
+
   async delete({ apiVersion, kind, namespace, name }) {
     const { apiGroup, resourceVersion } = parseApiVersion(apiVersion)
     const endpoint = getEndpoint(this.client, {

--- a/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
+++ b/sources/sdk/k8s-operator/tests/kube-interface/index.spec.js
@@ -38,6 +38,7 @@ describe('KubeInterface', () => {
   describe('get', require('./get'))
   describe('watch', require('./watch'))
   describe('patch', require('./patch'))
+  describe('replace', require('./replace'))
   describe('delete', require('./delete'))
   describe('logs', require('./logs'))
   describe('exec', require('./exec'))

--- a/sources/sdk/k8s-operator/tests/kube-interface/replace.js
+++ b/sources/sdk/k8s-operator/tests/kube-interface/replace.js
@@ -1,0 +1,51 @@
+const { it } = require('mocha')
+const { expect } = require('chai')
+
+const { KubeInterface } = require('../../src/index')
+
+module.exports = () => {
+  it('should replace a resource', async () => {
+    const kubectl = new KubeInterface({})
+    await kubectl.load()
+
+    const resp = await kubectl.replace({
+      apiVersion: 'example.com/v1',
+      kind: 'Example',
+      metadata: {
+        namespace: 'default',
+        name: 'example'
+      },
+      spec: {
+        foo: 'bar'
+      }
+    })
+
+    expect(resp).to.equal('DATA')
+  })
+
+  it('should throw an error if the replace failed', async () => {
+    const kubectl = new KubeInterface({})
+    await kubectl.load()
+
+    try {
+      await kubectl.replace({
+        apiVersion: 'example.com/v1',
+        kind: 'Failure',
+        metadata: {
+          namespace: 'default',
+          name: 'example'
+        },
+        spec: {
+          foo: 'bar'
+        }
+      })
+
+      throw new Error('no error has been thrown')
+    }
+    catch (err) {
+      expect(err.name).to.equal('KubeError')
+      expect(err.details?.resp?.statusCode).to.equal(404)
+      expect(err.details?.resp?.body).to.equal('ERROR')
+    }
+  })
+}

--- a/sources/sdk/k8s-operator/tests/mocks/kubernetes-client.js
+++ b/sources/sdk/k8s-operator/tests/mocks/kubernetes-client.js
@@ -20,6 +20,7 @@ const example = makeNamed(
   {
     get: sinon.stub().resolves({ statusCode: 200, body: 'DATA' }),
     patch: sinon.stub().resolves({ statusCode: 200, body: 'DATA' }),
+    put: sinon.stub().resolves({ statusCode: 200, body: 'DATA' }),
     delete: sinon.stub().resolves({ statusCode: 200, body: 'DATA' }),
     exec: {
       post: sinon.stub().resolves({ statusCode: 200, body: 'DATA' })
@@ -44,6 +45,7 @@ const failure = makeNamed(
   {
     get: sinon.stub().resolves({ statusCode: 404, body: 'ERROR' }),
     patch: sinon.stub().resolves({ statusCode: 404, body: 'ERROR' }),
+    put: sinon.stub().resolves({ statusCode: 404, body: 'ERROR' }),
     delete: sinon.stub().resolves({ statusCode: 404, body: 'ERROR' }),
     exec: {
       post: sinon.stub().resolves({ statusCode: 404, body: 'ERROR' })


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add `KubeInterface.replace(resource)` method to perform a `PUT` request
 - [x] :white_check_mark: Test Coverage