### PR TITLE
💄 Improve logging

### DIFF
--- a/apps/datapio_play/lib/datapio_play/dsl.ex
+++ b/apps/datapio_play/lib/datapio_play/dsl.ex
@@ -71,4 +71,13 @@ defmodule Datapio.Play.DSL do
       )
     end
   end
+
+  @doc """
+  Log a message from a step.
+  """
+  defmacro log(msg) do
+    quote do
+      Datapio.Play.StepLogger.new() |> Datapio.Play.StepLogger.print(msg)
+    end
+  end
 end

--- a/apps/datapio_play/lib/datapio_play/dsl.ex
+++ b/apps/datapio_play/lib/datapio_play/dsl.ex
@@ -77,7 +77,7 @@ defmodule Datapio.Play.DSL do
   """
   defmacro log(msg) do
     quote do
-      Datapio.Play.StepLogger.new() |> Datapio.Play.StepLogger.print(msg)
+      Datapio.Play.StepLogger.new() |> Datapio.Play.StepLogger.print(unquote(msg))
     end
   end
 end

--- a/apps/datapio_play/lib/datapio_play/dsl.ex
+++ b/apps/datapio_play/lib/datapio_play/dsl.ex
@@ -19,7 +19,8 @@ defmodule Datapio.Play.DSL do
   defmacro book(name, do: block) do
     quote do
       def run_book() do
-        IO.puts(IO.ANSI.format([:green, :bright, "===[ #{unquote(name)} ]==="]))
+        :ets.insert(:datapio_play_config, {:current_book, unquote(name)})
+        IO.puts(IO.ANSI.format([:green, :bright, "Book(#{unquote(name)}) ::"]))
 
         try do
           unquote(block)
@@ -38,7 +39,14 @@ defmodule Datapio.Play.DSL do
   """
   defmacro task(name, do: block) do
     quote do
-      IO.puts(IO.ANSI.format([:blue, :bright, ":: #{unquote(name)}"]))
+      book = case :ets.lookup(:datapio_play_config, :current_book) do
+        [] -> "no name"
+        [{:current_book, name}] -> name
+      end
+
+      :ets.insert(:datapio_play_config, {:current_task, unquote(name)})
+
+      IO.puts(IO.ANSI.format([:blue, :bright, "Book(#{book}) > Task(#{unquote(name)}) ::"]))
 
       try do
         unquote(block)

--- a/apps/datapio_play/lib/datapio_play/manifest.ex
+++ b/apps/datapio_play/lib/datapio_play/manifest.ex
@@ -4,7 +4,6 @@ defmodule Datapio.Play.Manifest do
   """
 
   alias Datapio.Play.BookNotFoundError
-  alias Datapio.Play.BookFailedError
 
   @doc """
   Defines what books to run and what task to perform in case of book failure.
@@ -26,6 +25,7 @@ defmodule Datapio.Play.Manifest do
           IO.puts(IO.ANSI.format([:red, :bright, "!! ERROR: #{Exception.message(e)}"]))
 
         e ->
+          :ets.insert(:datapio_play_config, {:current_book, :rescue})
           IO.puts(IO.ANSI.format([:red, :bright, "!! ERROR: #{Exception.message(e)}"]))
 
           unquote(on_failure)

--- a/apps/datapio_play/lib/datapio_play/step_logger.ex
+++ b/apps/datapio_play/lib/datapio_play/step_logger.ex
@@ -15,7 +15,7 @@ defmodule Datapio.Play.StepLogger do
       [{:current_step, name}] -> name
     end
 
-    prefix = IO.ANSI.format([:blue, "[#{book}] [#{task}] [#{step}] >>> "])
+    prefix = IO.ANSI.format([:blue, "Book(#{book}) > Task(#{task}) > Step(#{step}) >>> "])
     %__MODULE__{prefix: prefix}
   end
 
@@ -23,6 +23,6 @@ defmodule Datapio.Play.StepLogger do
     msg
       |> String.split(~r/\R/)
       |> Stream.filter(fn s -> String.length(s) > 0 end)
-      |> Enum.each(&IO.puts(logger.prefix <> &1))
+      |> Enum.each(fn s -> IO.puts("#{logger.prefix}#{s}") end)
   end
 end

--- a/apps/datapio_play/lib/datapio_play/step_logger.ex
+++ b/apps/datapio_play/lib/datapio_play/step_logger.ex
@@ -1,4 +1,8 @@
 defmodule Datapio.Play.StepLogger do
+  @moduledoc """
+  Print logs from steps.
+  """
+
   defstruct [:prefix]
 
   def new() do

--- a/apps/datapio_play/lib/datapio_play/step_logger.ex
+++ b/apps/datapio_play/lib/datapio_play/step_logger.ex
@@ -1,0 +1,28 @@
+defmodule Datapio.Play.StepLogger do
+  defstruct [:prefix]
+
+  def new() do
+    book = case :ets.lookup(:datapio_play_config, :current_book) do
+      [] -> "no name"
+      [{:current_book, name}] -> name
+    end
+    task = case :ets.lookup(:datapio_play_config, :current_task) do
+      [] -> "no name"
+      [{:current_task, name}] -> name
+    end
+    step = case :ets.lookup(:datapio_play_config, :current_step) do
+      [] -> "no name"
+      [{:current_step, name}] -> name
+    end
+
+    prefix = IO.ANSI.format([:blue, "[#{book}] [#{task}] [#{step}] >>> "])
+    %__MODULE__{prefix: prefix}
+  end
+
+  def print(%__MODULE__{} = logger, msg) do
+    msg
+      |> String.split(~r/\R/)
+      |> Stream.filter(fn s -> String.length(s) > 0 end)
+      |> Enum.each(&IO.puts(logger.prefix <> &1))
+  end
+end

--- a/apps/datapio_play/lib/datapio_play/step_logger_collectable.ex
+++ b/apps/datapio_play/lib/datapio_play/step_logger_collectable.ex
@@ -1,0 +1,18 @@
+defimpl Collectable, for: Datapio.Play.StepLogger do
+  def into(logger) do
+    collector_fun = fn
+      acc, {:cont, elem} ->
+        logger |> Datapio.Play.StepLogger.print(elem)
+        acc
+
+      acc, :done ->
+        acc
+
+      _, :halt ->
+        :ok
+    end
+
+    initial_acc = logger
+    {initial_acc, collector_fun}
+  end
+end


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add `StepLogger` to capture output and pre-format it before printing
 - [x] :recycle: Use `StepLogger` for `:shell` task
 - [x] :lipstick: Improve log messages
 - [x] :sparkles: Add `log` macro to call in custom steps 